### PR TITLE
Add GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- Brief 1-2 sentence description of what this PR does and why. -->
+
+Fixes #<!-- issue number -->
+
+## Changes
+
+<!-- Group changes by category. Delete sections that don't apply. -->
+
+**API**
+-
+
+**Internal**
+-
+
+## Breaking Changes
+
+<!-- Use one of: -->
+**None**
+
+<!-- OR list what changed and migration path:
+- `oldApi()` removed. Use `newApi()` instead.
+-->
+
+## Platform Support
+
+<!-- Check all that apply -->
+- [ ] Android
+- [ ] iOS
+- [ ] Desktop (JVM)
+- [ ] Web (Wasm)
+
+## Testing
+
+<!-- Describe how you tested. Include commands, devices, or test class names. -->
+
+- [ ] Unit tests pass
+- [ ] Manual testing on device/emulator
+- [ ] `./gradlew :lumen:compileKotlinMetadata` (commonMain)
+- [ ] `./gradlew :sample:assembleDebug` (sample app)
+
+## Release Notes
+
+<!-- One-liner for the changelog. Delete if not applicable. -->
+### Features
+-


### PR DESCRIPTION
## Summary

Adds a standardized PR description template based on patterns from top KMP/CMP open-source libraries (JetBrains compose-multiplatform, chrisbanes/haze, InsertKoinIO/koin).

## Changes

**Repository**
- Added `.github/pull_request_template.md` with sections: Summary, Changes, Breaking Changes, Platform Support, Testing, Release Notes

## Breaking Changes

**None**

## Testing

N/A - repository configuration only.