### PR TITLE
Add iOS NSUserDefaults storage + document persistence API

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -222,17 +222,17 @@ CoachmarkTarget(
 True cross-platform coachmarks:
 
 #### Platform Support
-- [ ] **Android** — Full feature parity (current)
-- [ ] **iOS** — Compose Multiplatform for iOS
+- [x] **Android** — Full feature parity (shipping)
+- [x] **iOS** — Compose Multiplatform for iOS (shipping)
 - [ ] **Desktop** — macOS, Windows, Linux
 - [ ] **Web** — Compose for Web (Wasm)
 
 #### Platform Abstractions
-- [ ] **expect/actual for Persistence**
-  - Android: SharedPreferences
-  - iOS: NSUserDefaults
-  - Desktop: java.util.prefs
-  - Web: localStorage
+- [x] **Interface-based Persistence** (CoachmarkStorage interface, not expect/actual)
+  - [x] Android: SharedPreferences
+  - [x] iOS: NSUserDefaults
+  - [ ] Desktop: java.util.prefs
+  - [ ] Web: localStorage
 
 - [ ] **expect/actual for Haptics**
   - Android: VibrationEffect
@@ -273,7 +273,7 @@ compose-spotlight/
 | Analytics callbacks | | | ✅ | ✅ | ✅ |
 | DSL builder | | | | ✅ | ✅ |
 | Custom tooltip content | | | | ✅ | ✅ |
-| iOS support | | | | | ✅ |
+| iOS support | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Desktop support | | | | | ✅ |
 | Web support | | | | | ✅ |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -433,3 +433,59 @@ fun coachmarkColors(
     darkTheme: Boolean = isSystemInDarkTheme()
 ): CoachmarkColors
 ```
+
+---
+
+## Persistence
+
+### CoachmarkStorage
+
+Interface for coachmark persistence storage. Implement this to provide a custom storage mechanism.
+
+```kotlin
+interface CoachmarkStorage {
+    fun getBoolean(key: String, default: Boolean): Boolean
+    fun putBoolean(key: String, value: Boolean)
+    fun remove(key: String)
+    fun getAllKeys(): Set<String>
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `getBoolean(key, default)` | Read a boolean value, returning `default` if not found |
+| `putBoolean(key, value)` | Write a boolean value |
+| `remove(key)` | Remove a stored key |
+| `getAllKeys()` | Return all stored keys |
+
+#### Platform Implementations
+
+| Platform | Class | Storage Backend |
+|----------|-------|-----------------|
+| Android | `SharedPrefsCoachmarkStorage(context)` | SharedPreferences |
+| iOS | `NSUserDefaultsCoachmarkStorage()` | NSUserDefaults |
+
+### CoachmarkRepository
+
+Repository for persisting coachmark shown state. Tracks which coachmarks have been seen to prevent showing them again.
+
+```kotlin
+class CoachmarkRepository(storage: CoachmarkStorage)
+```
+
+| Method | Description |
+|--------|-------------|
+| `hasSeenCoachmark(id: String): Boolean` | Check if a coachmark has been seen |
+| `markCoachmarkSeen(id: String)` | Mark a coachmark as seen |
+| `resetCoachmark(id: String)` | Reset a coachmark to unseen state |
+| `resetAllCoachmarks()` | Reset all coachmarks to unseen state |
+
+#### Convenience Factories
+
+```kotlin
+// Android
+fun CoachmarkRepository(context: Context): CoachmarkRepository
+
+// iOS
+fun CoachmarkRepository(): CoachmarkRepository
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,6 +141,10 @@ fun OnboardingScreen() {
 
 Lumen is a Kotlin Multiplatform library. Add it to `commonMain` dependencies and it works on both Android and iOS. All APIs are identical across platforms.
 
+## Optional: Persistence
+
+Want coachmarks to show only once? Use `CoachmarkRepository` to track which coachmarks have been seen. See the [Persistence guide](guide.md#persistence) for setup on Android and iOS.
+
 ## Next Steps
 
 - Learn about [Multi-Step Sequences](guide.md#multi-step-sequences)

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -338,3 +338,57 @@ Useful when:
 - Screen is animating in
 - Data is loading
 - Layout may shift
+
+## Persistence
+
+Track which coachmarks have been shown so they only appear once per user.
+
+### Android
+
+```kotlin
+val repository = CoachmarkRepository(context)
+```
+
+Uses `SharedPreferences` under the hood.
+
+### iOS
+
+```kotlin
+val repository = CoachmarkRepository()
+```
+
+Uses `NSUserDefaults` under the hood.
+
+### Using the Repository
+
+```kotlin
+val repository = CoachmarkRepository(context) // Android
+// val repository = CoachmarkRepository()     // iOS
+
+// Check before showing
+if (!repository.hasSeenCoachmark("onboarding")) {
+    controller.show(onboardingTarget)
+}
+
+// Mark as seen after completion
+repository.markCoachmarkSeen("onboarding")
+
+// Reset for testing or "replay tutorial"
+repository.resetCoachmark("onboarding")
+repository.resetAllCoachmarks()
+```
+
+### Custom Storage
+
+Implement `CoachmarkStorage` to use your own persistence backend:
+
+```kotlin
+class MyCustomStorage : CoachmarkStorage {
+    override fun getBoolean(key: String, default: Boolean): Boolean = TODO()
+    override fun putBoolean(key: String, value: Boolean) = TODO()
+    override fun remove(key: String) = TODO()
+    override fun getAllKeys(): Set<String> = TODO()
+}
+
+val repository = CoachmarkRepository(MyCustomStorage())
+```

--- a/lumen/src/commonMain/kotlin/io/luminos/CoachmarkRepository.kt
+++ b/lumen/src/commonMain/kotlin/io/luminos/CoachmarkRepository.kt
@@ -19,6 +19,7 @@ interface CoachmarkStorage {
  *
  * @param storage The storage mechanism to use for persistence.
  *                On Android, use [SharedPrefsCoachmarkStorage] for the default implementation.
+ *                On iOS, use [NSUserDefaultsCoachmarkStorage] for the default implementation.
  */
 class CoachmarkRepository(
     private val storage: CoachmarkStorage,

--- a/lumen/src/iosMain/kotlin/io/luminos/IosCoachmarkRepository.kt
+++ b/lumen/src/iosMain/kotlin/io/luminos/IosCoachmarkRepository.kt
@@ -1,0 +1,32 @@
+package io.luminos
+
+import platform.Foundation.NSUserDefaults
+
+/**
+ * Default implementation using iOS NSUserDefaults.
+ */
+class NSUserDefaultsCoachmarkStorage : CoachmarkStorage {
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    override fun getBoolean(key: String, default: Boolean): Boolean =
+        if (defaults.objectForKey(key) != null) defaults.boolForKey(key) else default
+
+    override fun putBoolean(key: String, value: Boolean) {
+        defaults.setBool(value, forKey = key)
+    }
+
+    override fun remove(key: String) {
+        defaults.removeObjectForKey(key)
+    }
+
+    override fun getAllKeys(): Set<String> =
+        defaults.dictionaryRepresentation().keys
+            .filterIsInstance<String>()
+            .toSet()
+}
+
+/**
+ * Convenience function to create a [CoachmarkRepository] with iOS NSUserDefaults.
+ */
+fun CoachmarkRepository(): CoachmarkRepository =
+    CoachmarkRepository(NSUserDefaultsCoachmarkStorage())


### PR DESCRIPTION
## Summary

Add iOS `NSUserDefaultsCoachmarkStorage` for platform parity with Android's `SharedPrefsCoachmarkStorage`, and document the previously undocumented persistence API across all docs.

## Changes

**API**
- Add `NSUserDefaultsCoachmarkStorage` class in `iosMain` implementing `CoachmarkStorage`
- Add convenience factory `CoachmarkRepository()` for iOS (no params — NSUserDefaults is a singleton)
- Update `CoachmarkRepository` KDoc to reference both Android and iOS implementations

**Docs**
- `docs/api-reference.md` — Add Persistence section (CoachmarkStorage, CoachmarkRepository, platform implementations)
- `docs/guide.md` — Add Persistence section with Android/iOS setup and custom storage example
- `docs/architecture.md` — Fix stale expect/actual code example → actual interface-based pattern; update file paths to `io/luminos/`; check off iOS NSUserDefaults
- `docs/getting-started.md` — Add persistence note before "Next Steps"
- `ROADMAP.md` — Check off iOS platform support (was incorrectly listed as v2.0 future); update persistence to reflect interface-based pattern

## Breaking Changes

**None**

## Platform Support

- [x] Android
- [x] iOS
- [ ] Desktop (JVM)
- [ ] Web (Wasm)

## Testing

- [ ] Unit tests pass
- [ ] Manual testing on device/emulator
- [x] `./gradlew :lumen:compileKotlinIosArm64`
- [x] `./gradlew :lumen:compileKotlinIosX64`
- [x] `./gradlew :lumen:compileKotlinIosSimulatorArm64`
- [x] `./gradlew :lumen:compileReleaseKotlinAndroid` (no regression)

## Release Notes

### Features
- iOS `NSUserDefaultsCoachmarkStorage` for built-in persistence support on iOS