### PR TITLE
Add connector endpoint styles, Bezier curves, and custom endpoints

### DIFF
--- a/lumen/api/android/lumen.api
+++ b/lumen/api/android/lumen.api
@@ -52,37 +52,43 @@ public final class io/luminos/CoachmarkColorsKt {
 
 public final class io/luminos/CoachmarkConfig {
 	public static final field $stable I
-	public synthetic fun <init> (FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-D9Ej5fM ()F
-	public final fun component10 ()Lio/luminos/ScrimOpacity;
-	public final fun component11 ()Lio/luminos/ScrimTapBehavior;
-	public final fun component12 ()Z
-	public final fun component13 ()Z
-	public final fun component14 ()Lio/luminos/BackPressBehavior;
-	public final fun component15 ()Lio/luminos/HighlightAnimation;
-	public final fun component16 ()I
-	public final fun component17 ()Z
-	public final fun component18 ()Ljava/lang/String;
-	public final fun component19 ()J
+	public final fun component10 ()I
+	public final fun component11 ()I
+	public final fun component12 ()I
+	public final fun component13 ()Lio/luminos/ScrimOpacity;
+	public final fun component14 ()Lio/luminos/ScrimTapBehavior;
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Lio/luminos/BackPressBehavior;
+	public final fun component18 ()Lio/luminos/HighlightAnimation;
+	public final fun component19 ()I
 	public final fun component2-D9Ej5fM ()F
 	public final fun component20 ()Z
-	public final fun component21 ()J
+	public final fun component21 ()Ljava/lang/String;
 	public final fun component22 ()J
+	public final fun component23 ()Z
+	public final fun component24 ()J
+	public final fun component25 ()J
 	public final fun component3-D9Ej5fM ()F
-	public final fun component4-D9Ej5fM ()F
-	public final fun component5-D9Ej5fM ()F
+	public final fun component4 ()F
+	public final fun component5 ()Lkotlin/jvm/functions/Function3;
 	public final fun component6-D9Ej5fM ()F
-	public final fun component7 ()I
-	public final fun component8 ()I
-	public final fun component9 ()I
-	public final fun copy-hd5cb-E (FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJ)Lio/luminos/CoachmarkConfig;
-	public static synthetic fun copy-hd5cb-E$default (Lio/luminos/CoachmarkConfig;FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILjava/lang/Object;)Lio/luminos/CoachmarkConfig;
+	public final fun component7-D9Ej5fM ()F
+	public final fun component8-D9Ej5fM ()F
+	public final fun component9-D9Ej5fM ()F
+	public final fun copy-q0gudl0 (FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJ)Lio/luminos/CoachmarkConfig;
+	public static synthetic fun copy-q0gudl0$default (Lio/luminos/CoachmarkConfig;FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILjava/lang/Object;)Lio/luminos/CoachmarkConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackPressBehavior ()Lio/luminos/BackPressBehavior;
 	public final fun getConnectorAnimationDuration ()I
+	public final fun getConnectorArrowAngle ()F
+	public final fun getConnectorArrowSize-D9Ej5fM ()F
 	public final fun getConnectorDotRadius-D9Ej5fM ()F
 	public final fun getConnectorTooltipGap-D9Ej5fM ()F
+	public final fun getCustomConnectorEnd ()Lkotlin/jvm/functions/Function3;
 	public final fun getDelayBeforeShow ()J
 	public final fun getFadeAnimationDuration ()I
 	public final fun getHighlightAnimation ()Lio/luminos/HighlightAnimation;
@@ -214,11 +220,12 @@ public abstract interface class io/luminos/CoachmarkStorage {
 
 public final class io/luminos/CoachmarkTarget {
 	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/Boolean;
-	public final fun component11 ()Lio/luminos/HighlightAnimation;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Lio/luminos/HighlightAnimation;
 	public final fun component2 ()Landroidx/compose/ui/geometry/Rect;
 	public final fun component3 ()Lio/luminos/CutoutShape;
 	public final fun component4 ()Ljava/lang/String;
@@ -226,11 +233,12 @@ public final class io/luminos/CoachmarkTarget {
 	public final fun component6 ()Lio/luminos/TooltipPosition;
 	public final fun component7 ()Lio/luminos/ConnectorStyle;
 	public final fun component8-D9Ej5fM ()F
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy-egy_3UM (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;)Lio/luminos/CoachmarkTarget;
-	public static synthetic fun copy-egy_3UM$default (Lio/luminos/CoachmarkTarget;Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILjava/lang/Object;)Lio/luminos/CoachmarkTarget;
+	public final fun component9 ()Lio/luminos/ConnectorEndStyle;
+	public final fun copy-gMrHQkA (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;)Lio/luminos/CoachmarkTarget;
+	public static synthetic fun copy-gMrHQkA$default (Lio/luminos/CoachmarkTarget;Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILjava/lang/Object;)Lio/luminos/CoachmarkTarget;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Landroidx/compose/ui/geometry/Rect;
+	public final fun getConnectorEndStyle ()Lio/luminos/ConnectorEndStyle;
 	public final fun getConnectorLength-D9Ej5fM ()F
 	public final fun getConnectorStyle ()Lio/luminos/ConnectorStyle;
 	public final fun getCtaText ()Ljava/lang/String;
@@ -249,8 +257,19 @@ public final class io/luminos/CoachmarkTooltipKt {
 	public static final fun CoachmarkTooltip-AlbwjTQ (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILio/luminos/CoachmarkColors;FZZZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;III)V
 }
 
+public final class io/luminos/ConnectorEndStyle : java/lang/Enum {
+	public static final field ARROW Lio/luminos/ConnectorEndStyle;
+	public static final field CUSTOM Lio/luminos/ConnectorEndStyle;
+	public static final field DOT Lio/luminos/ConnectorEndStyle;
+	public static final field NONE Lio/luminos/ConnectorEndStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/luminos/ConnectorEndStyle;
+	public static fun values ()[Lio/luminos/ConnectorEndStyle;
+}
+
 public final class io/luminos/ConnectorStyle : java/lang/Enum {
 	public static final field AUTO Lio/luminos/ConnectorStyle;
+	public static final field CURVED Lio/luminos/ConnectorStyle;
 	public static final field DIRECT Lio/luminos/ConnectorStyle;
 	public static final field ELBOW Lio/luminos/ConnectorStyle;
 	public static final field HORIZONTAL Lio/luminos/ConnectorStyle;

--- a/lumen/api/jvm/lumen.api
+++ b/lumen/api/jvm/lumen.api
@@ -48,37 +48,43 @@ public final class io/luminos/CoachmarkColorsKt {
 
 public final class io/luminos/CoachmarkConfig {
 	public static final field $stable I
-	public synthetic fun <init> (FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-D9Ej5fM ()F
-	public final fun component10 ()Lio/luminos/ScrimOpacity;
-	public final fun component11 ()Lio/luminos/ScrimTapBehavior;
-	public final fun component12 ()Z
-	public final fun component13 ()Z
-	public final fun component14 ()Lio/luminos/BackPressBehavior;
-	public final fun component15 ()Lio/luminos/HighlightAnimation;
-	public final fun component16 ()I
-	public final fun component17 ()Z
-	public final fun component18 ()Ljava/lang/String;
-	public final fun component19 ()J
+	public final fun component10 ()I
+	public final fun component11 ()I
+	public final fun component12 ()I
+	public final fun component13 ()Lio/luminos/ScrimOpacity;
+	public final fun component14 ()Lio/luminos/ScrimTapBehavior;
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Lio/luminos/BackPressBehavior;
+	public final fun component18 ()Lio/luminos/HighlightAnimation;
+	public final fun component19 ()I
 	public final fun component2-D9Ej5fM ()F
 	public final fun component20 ()Z
-	public final fun component21 ()J
+	public final fun component21 ()Ljava/lang/String;
 	public final fun component22 ()J
+	public final fun component23 ()Z
+	public final fun component24 ()J
+	public final fun component25 ()J
 	public final fun component3-D9Ej5fM ()F
-	public final fun component4-D9Ej5fM ()F
-	public final fun component5-D9Ej5fM ()F
+	public final fun component4 ()F
+	public final fun component5 ()Lkotlin/jvm/functions/Function3;
 	public final fun component6-D9Ej5fM ()F
-	public final fun component7 ()I
-	public final fun component8 ()I
-	public final fun component9 ()I
-	public final fun copy-hd5cb-E (FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJ)Lio/luminos/CoachmarkConfig;
-	public static synthetic fun copy-hd5cb-E$default (Lio/luminos/CoachmarkConfig;FFFFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILjava/lang/Object;)Lio/luminos/CoachmarkConfig;
+	public final fun component7-D9Ej5fM ()F
+	public final fun component8-D9Ej5fM ()F
+	public final fun component9-D9Ej5fM ()F
+	public final fun copy-q0gudl0 (FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJ)Lio/luminos/CoachmarkConfig;
+	public static synthetic fun copy-q0gudl0$default (Lio/luminos/CoachmarkConfig;FFFFLkotlin/jvm/functions/Function3;FFFFIIILio/luminos/ScrimOpacity;Lio/luminos/ScrimTapBehavior;ZZLio/luminos/BackPressBehavior;Lio/luminos/HighlightAnimation;IZLjava/lang/String;JZJJILjava/lang/Object;)Lio/luminos/CoachmarkConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackPressBehavior ()Lio/luminos/BackPressBehavior;
 	public final fun getConnectorAnimationDuration ()I
+	public final fun getConnectorArrowAngle ()F
+	public final fun getConnectorArrowSize-D9Ej5fM ()F
 	public final fun getConnectorDotRadius-D9Ej5fM ()F
 	public final fun getConnectorTooltipGap-D9Ej5fM ()F
+	public final fun getCustomConnectorEnd ()Lkotlin/jvm/functions/Function3;
 	public final fun getDelayBeforeShow ()J
 	public final fun getFadeAnimationDuration ()I
 	public final fun getHighlightAnimation ()Lio/luminos/HighlightAnimation;
@@ -210,11 +216,12 @@ public abstract interface class io/luminos/CoachmarkStorage {
 
 public final class io/luminos/CoachmarkTarget {
 	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/Boolean;
-	public final fun component11 ()Lio/luminos/HighlightAnimation;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Lio/luminos/HighlightAnimation;
 	public final fun component2 ()Landroidx/compose/ui/geometry/Rect;
 	public final fun component3 ()Lio/luminos/CutoutShape;
 	public final fun component4 ()Ljava/lang/String;
@@ -222,11 +229,12 @@ public final class io/luminos/CoachmarkTarget {
 	public final fun component6 ()Lio/luminos/TooltipPosition;
 	public final fun component7 ()Lio/luminos/ConnectorStyle;
 	public final fun component8-D9Ej5fM ()F
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy-egy_3UM (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;)Lio/luminos/CoachmarkTarget;
-	public static synthetic fun copy-egy_3UM$default (Lio/luminos/CoachmarkTarget;Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLjava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILjava/lang/Object;)Lio/luminos/CoachmarkTarget;
+	public final fun component9 ()Lio/luminos/ConnectorEndStyle;
+	public final fun copy-gMrHQkA (Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;)Lio/luminos/CoachmarkTarget;
+	public static synthetic fun copy-gMrHQkA$default (Lio/luminos/CoachmarkTarget;Ljava/lang/String;Landroidx/compose/ui/geometry/Rect;Lio/luminos/CutoutShape;Ljava/lang/String;Ljava/lang/String;Lio/luminos/TooltipPosition;Lio/luminos/ConnectorStyle;FLio/luminos/ConnectorEndStyle;Ljava/lang/String;Ljava/lang/Boolean;Lio/luminos/HighlightAnimation;ILjava/lang/Object;)Lio/luminos/CoachmarkTarget;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Landroidx/compose/ui/geometry/Rect;
+	public final fun getConnectorEndStyle ()Lio/luminos/ConnectorEndStyle;
 	public final fun getConnectorLength-D9Ej5fM ()F
 	public final fun getConnectorStyle ()Lio/luminos/ConnectorStyle;
 	public final fun getCtaText ()Ljava/lang/String;
@@ -245,8 +253,19 @@ public final class io/luminos/CoachmarkTooltipKt {
 	public static final fun CoachmarkTooltip-AlbwjTQ (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILio/luminos/CoachmarkColors;FZZZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;III)V
 }
 
+public final class io/luminos/ConnectorEndStyle : java/lang/Enum {
+	public static final field ARROW Lio/luminos/ConnectorEndStyle;
+	public static final field CUSTOM Lio/luminos/ConnectorEndStyle;
+	public static final field DOT Lio/luminos/ConnectorEndStyle;
+	public static final field NONE Lio/luminos/ConnectorEndStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/luminos/ConnectorEndStyle;
+	public static fun values ()[Lio/luminos/ConnectorEndStyle;
+}
+
 public final class io/luminos/ConnectorStyle : java/lang/Enum {
 	public static final field AUTO Lio/luminos/ConnectorStyle;
+	public static final field CURVED Lio/luminos/ConnectorStyle;
 	public static final field DIRECT Lio/luminos/ConnectorStyle;
 	public static final field ELBOW Lio/luminos/ConnectorStyle;
 	public static final field HORIZONTAL Lio/luminos/ConnectorStyle;

--- a/lumen/src/commonMain/kotlin/io/luminos/CoachmarkTarget.kt
+++ b/lumen/src/commonMain/kotlin/io/luminos/CoachmarkTarget.kt
@@ -172,6 +172,21 @@ enum class ConnectorStyle {
      * L-shaped connector: horizontal from cutout edge, then 90 degree turn down/up to tooltip.
      */
     ELBOW,
+
+    /** Smooth curved connector using a quadratic Bezier curve. */
+    CURVED,
+}
+
+/** Visual style at the endpoint of the connector line. */
+enum class ConnectorEndStyle {
+    /** Small filled circle (current default). */
+    DOT,
+    /** Directional arrowhead pointing toward the tooltip. */
+    ARROW,
+    /** No endpoint decoration. */
+    NONE,
+    /** Custom rendering via CoachmarkConfig.customConnectorEnd lambda. */
+    CUSTOM,
 }
 
 /**
@@ -185,6 +200,7 @@ enum class ConnectorStyle {
  * @property tooltipPosition Where to position the tooltip relative to the target
  * @property connectorStyle The style/angle of the connector line
  * @property connectorLength Length of connector line (Dp.Unspecified = auto/default 40dp)
+ * @property connectorEndStyle Visual style at the endpoint of the connector line
  * @property ctaText Custom CTA button text (defaults to "Got it!")
  * @property showProgressIndicator Override for progress indicator visibility.
  *           - `null` (default): Use global [CoachmarkConfig.showProgressIndicator]
@@ -204,6 +220,7 @@ data class CoachmarkTarget(
     val tooltipPosition: TooltipPosition = TooltipPosition.AUTO,
     val connectorStyle: ConnectorStyle = ConnectorStyle.AUTO,
     val connectorLength: Dp = Dp.Unspecified,
+    val connectorEndStyle: ConnectorEndStyle = ConnectorEndStyle.DOT,
     val ctaText: String = "Got it!",
     val showProgressIndicator: Boolean? = null,
     val highlightAnimation: HighlightAnimation? = null,

--- a/lumen/src/commonTest/kotlin/io/luminos/CoachmarkTargetTest.kt
+++ b/lumen/src/commonTest/kotlin/io/luminos/CoachmarkTargetTest.kt
@@ -152,12 +152,29 @@ class CoachmarkTargetTest {
     @Test
     fun connectorStyle_values() {
         val values = ConnectorStyle.entries
-        assertEquals(5, values.size)
+        assertEquals(6, values.size)
         assertTrue(values.contains(ConnectorStyle.AUTO))
         assertTrue(values.contains(ConnectorStyle.DIRECT))
         assertTrue(values.contains(ConnectorStyle.HORIZONTAL))
         assertTrue(values.contains(ConnectorStyle.VERTICAL))
         assertTrue(values.contains(ConnectorStyle.ELBOW))
+        assertTrue(values.contains(ConnectorStyle.CURVED))
+    }
+
+    @Test
+    fun default_connectorEndStyle_is_DOT() {
+        val target = CoachmarkTarget(id = "t1", title = "T", description = "D")
+        assertEquals(ConnectorEndStyle.DOT, target.connectorEndStyle)
+    }
+
+    @Test
+    fun connectorEndStyle_values() {
+        val values = ConnectorEndStyle.entries
+        assertEquals(4, values.size)
+        assertTrue(values.contains(ConnectorEndStyle.DOT))
+        assertTrue(values.contains(ConnectorEndStyle.ARROW))
+        assertTrue(values.contains(ConnectorEndStyle.NONE))
+        assertTrue(values.contains(ConnectorEndStyle.CUSTOM))
     }
 
     // ── CutoutShape sealed hierarchy ─────────────────────────────────────

--- a/sample/src/commonMain/kotlin/com/aditlal/sample/examples/ConnectorsExample.kt
+++ b/sample/src/commonMain/kotlin/com/aditlal/sample/examples/ConnectorsExample.kt
@@ -35,10 +35,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
 import io.luminos.CoachmarkConfig
 import io.luminos.CoachmarkHost
 import io.luminos.CoachmarkTarget
+import io.luminos.ConnectorEndStyle
 import io.luminos.ConnectorStyle
 import io.luminos.CutoutShape
 import io.luminos.HighlightAnimation
@@ -63,6 +69,26 @@ fun ConnectorsExample(
             showSkipButton = true,
             skipButtonText = "Skip",
             scrimTapBehavior = ScrimTapBehavior.NONE,
+            customConnectorEnd = { center, angle ->
+                // Diamond shape endpoint
+                val size = 10f
+                val path = Path()
+                path.moveTo(center.x + size * cos(angle), center.y + size * sin(angle))
+                path.lineTo(
+                    center.x + size * cos(angle + PI.toFloat() / 2f),
+                    center.y + size * sin(angle + PI.toFloat() / 2f),
+                )
+                path.lineTo(
+                    center.x + size * cos(angle + PI.toFloat()),
+                    center.y + size * sin(angle + PI.toFloat()),
+                )
+                path.lineTo(
+                    center.x + size * cos(angle - PI.toFloat() / 2f),
+                    center.y + size * sin(angle - PI.toFloat() / 2f),
+                )
+                path.close()
+                drawPath(path = path, color = Color.White)
+            },
         ),
         colors = coachmarkColors(),
     ) {
@@ -108,7 +134,7 @@ fun ConnectorsExample(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Text(
-                    text = "Five different ways to connect tooltips to targets",
+                    text = "Eight different ways to connect tooltips to targets",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -226,11 +252,40 @@ fun ConnectorsExample(
                     ctaText = "Next",
                 ),
                 CoachmarkTarget(
+                    id = "horizontal",
+                    title = "Arrow Connector",
+                    description = "Arrowhead endpoint pointing toward the tooltip for clear directionality.",
+                    shape = CutoutShape.Circle(radiusPadding = 10.dp),
+                    connectorStyle = ConnectorStyle.DIRECT,
+                    connectorEndStyle = ConnectorEndStyle.ARROW,
+                    connectorLength = 80.dp,
+                    ctaText = "Next",
+                ),
+                CoachmarkTarget(
+                    id = "vertical",
+                    title = "Curved Connector",
+                    description = "Smooth Bezier curve for an elegant flowing line.",
+                    shape = CutoutShape.Circle(radiusPadding = 10.dp),
+                    connectorStyle = ConnectorStyle.CURVED,
+                    connectorLength = 80.dp,
+                    ctaText = "Next",
+                ),
+                CoachmarkTarget(
                     id = "settings",
                     title = "Auto Connector",
                     description = "Automatically picks the best connector style based on target position. Recommended for most use cases.",
                     shape = CutoutShape.Circle(radiusPadding = 10.dp),
                     connectorStyle = ConnectorStyle.AUTO,
+                    connectorLength = 90.dp,
+                    ctaText = "Next",
+                ),
+                CoachmarkTarget(
+                    id = "notifications",
+                    title = "Custom Endpoint",
+                    description = "Provide a DrawScope lambda for fully custom endpoint rendering.",
+                    shape = CutoutShape.Circle(radiusPadding = 10.dp),
+                    connectorStyle = ConnectorStyle.ELBOW,
+                    connectorEndStyle = ConnectorEndStyle.CUSTOM,
                     connectorLength = 90.dp,
                     ctaText = "Got it!",
                 ),


### PR DESCRIPTION
## Summary

Add connector endpoint styles (arrow, none, custom), Bezier curve connectors, and custom endpoint lambda support.

Fixes #6, fixes #7, fixes #8

<img width="300" alt="Arrow & Curved connectors" src="https://github.com/user-attachments/assets/d5887225-d523-4e30-b1e4-ccf380f548e5" /> <img width="300" alt="Custom endpoint" src="https://github.com/user-attachments/assets/60beeb97-5555-4f88-a62b-9f79c2883345" />

## Changes

**API**
- Add `ConnectorStyle.CURVED` for smooth quadratic Bezier curve connectors
- Add `ConnectorEndStyle` enum (`DOT`, `ARROW`, `NONE`, `CUSTOM`) for endpoint visuals
- Add `connectorEndStyle` property to `CoachmarkTarget` (default `DOT`)
- Add `connectorArrowSize`, `connectorArrowAngle`, `customConnectorEnd` to `CoachmarkConfig`

**Internal**
- Refactor connector rendering pipeline with `ConnectorPathData` sealed interface (`Segments` / `Curve`)
- Add `drawArrowHead`, `drawConnectorCurve`, `calculateConnectorAngle` helpers
- Extract `drawConnectorEndpoint` dispatch for all endpoint styles

## New API Surface

| Type | Addition | Default |
|------|----------|---------|
| `ConnectorStyle` | `CURVED` | — |
| `ConnectorEndStyle` | `DOT`, `ARROW`, `NONE`, `CUSTOM` | `DOT` |
| `CoachmarkTarget` | `connectorEndStyle` | `DOT` |
| `CoachmarkConfig` | `connectorArrowSize` | `10.dp` |
| `CoachmarkConfig` | `connectorArrowAngle` | `30f` |
| `CoachmarkConfig` | `customConnectorEnd` | `null` |

## Breaking Changes

**None** — all new properties have defaults, fully backward compatible.

## Platform Support

- [x] Android
- [x] iOS
- [x] Desktop (JVM)
- [x] Web (Wasm)

## Testing

- [x] Unit tests pass (`./gradlew allTests` — JVM, Android, iOS simulator, WasmJs)
- [x] Manual testing on desktop
- [x] `./gradlew apiCheck` (API compatibility verified)

## Release Notes

### Features
- Arrow endpoint style for connectors with configurable size and angle
- Smooth Bezier curve connector style (`CURVED`)
- Custom endpoint rendering via `DrawScope` lambda
- `NONE` endpoint style to hide connector dots