### PR TITLE
Update docs for connector endpoints, Bezier curves, and platform support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,9 +90,9 @@ CoachmarkConfig(
 ```
 
 #### Connector Enhancements
-- [ ] **Arrow End Style** — Optional arrow head on connector
-- [ ] **Custom Connector End** — DrawScope lambda for custom shapes
-- [ ] **Curved Connectors** — Bezier curve option
+- [x] **Arrow End Style** — Optional arrow head on connector
+- [x] **Custom Connector End** — DrawScope lambda for custom shapes
+- [x] **Curved Connectors** — Bezier curve option
 
 ```kotlin
 enum class ConnectorEndStyle {
@@ -228,8 +228,8 @@ True cross-platform coachmarks:
 #### Platform Support
 - [x] **Android** — Full feature parity (shipping)
 - [x] **iOS** — Compose Multiplatform for iOS (shipping)
-- [ ] **Desktop** — macOS, Windows, Linux
-- [ ] **Web** — Compose for Web (Wasm)
+- [x] **Desktop** — macOS, Windows, Linux
+- [x] **Web** — Compose for Web (Wasm)
 
 #### Platform Abstractions
 - [x] **Interface-based Persistence** (CoachmarkStorage interface, not expect/actual)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,14 +4,15 @@
 
 Lumen is a Compose Multiplatform coachmark library that creates **true transparent cutouts** in the overlay scrim. Your actual UI remains visible and interactive through the spotlight - animations play, buttons respond, nothing is faked.
 
-> **Supports Android and iOS** via Kotlin Multiplatform.
+> **Supports Android, iOS, Desktop (JVM), and Web (Wasm)** via Kotlin Multiplatform.
 
 ## Features
 
 - **True Transparent Cutouts** - Uses `BlendMode.Clear` for genuine transparency
 - **5 Cutout Shapes** - Circle, Rect, RoundedRect, Squircle, Star
 - **6 Highlight Animations** - Pulse, Glow, Ripple, Shimmer, Bounce, or static
-- **5 Connector Styles** - Connect tooltips to targets with various line styles
+- **6 Connector Styles** - Straight, elbow, curved Bezier, and more
+- **4 Connector End Styles** - Dot, arrow, none, or custom DrawScope rendering
 - **Multi-Step Sequences** - Build onboarding tours with progress indicators
 - **Dialog Coordination** - Automatically handles overlay conflicts
 - **Full Theming** - Customize every color and dimension

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -9,6 +9,7 @@
   - [Multi-Step Sequences](guide.md#multi-step-sequences)
   - [Cutout Shapes](guide.md#cutout-shapes)
   - [Highlight Animations](guide.md#highlight-animations)
+  - [Connector End Styles](guide.md#connector-end-styles)
   - [Theming](guide.md#theming)
   - [Dialog Coordination](guide.md#dialog-coordination)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,6 +80,7 @@ data class CoachmarkTarget(
     val tooltipPosition: TooltipPosition = TooltipPosition.AUTO,
     val connectorStyle: ConnectorStyle = ConnectorStyle.AUTO,
     val connectorLength: Dp = Dp.Unspecified,
+    val connectorEndStyle: ConnectorEndStyle = ConnectorEndStyle.DOT,
     val ctaText: String = "Got it!",
     val showProgressIndicator: Boolean? = null,
     val highlightAnimation: HighlightAnimation? = null,
@@ -96,6 +97,7 @@ data class CoachmarkTarget(
 | `tooltipPosition` | `TooltipPosition` | `AUTO` | Where tooltip appears relative to target |
 | `connectorStyle` | `ConnectorStyle` | `AUTO` | Style of connector line |
 | `connectorLength` | `Dp` | `Unspecified` | Connector length (auto: 40dp) |
+| `connectorEndStyle` | `ConnectorEndStyle` | `DOT` | Endpoint decoration style |
 | `ctaText` | `String` | `"Got it!"` | Call-to-action button text |
 | `showProgressIndicator` | `Boolean?` | `null` | Override global progress setting |
 | `highlightAnimation` | `HighlightAnimation?` | `null` | Override global animation |
@@ -186,6 +188,9 @@ Configuration for coachmark appearance and behavior.
 data class CoachmarkConfig(
     val strokeWidth: Dp = 2.dp,
     val connectorDotRadius: Dp = 4.dp,
+    val connectorArrowSize: Dp = 10.dp,
+    val connectorArrowAngle: Float = 30f,
+    val customConnectorEnd: (DrawScope.(center: Offset, angle: Float) -> Unit)? = null,
     val tooltipMargin: Dp = 16.dp,
     val tooltipGap: Dp = 16.dp,
     val tooltipCornerRadius: Dp = 16.dp,
@@ -210,6 +215,9 @@ data class CoachmarkConfig(
 |----------|------|---------|-------------|
 | `strokeWidth` | `Dp` | `2.dp` | Cutout border stroke width |
 | `connectorDotRadius` | `Dp` | `4.dp` | Radius of connector endpoint dot |
+| `connectorArrowSize` | `Dp` | `10.dp` | Length of arrowhead for `ARROW` end style |
+| `connectorArrowAngle` | `Float` | `30f` | Half-angle of arrowhead wings in degrees |
+| `customConnectorEnd` | `DrawScope.(Offset, Float) -> Unit` | `null` | Custom endpoint rendering lambda for `CUSTOM` end style |
 | `tooltipMargin` | `Dp` | `16.dp` | Minimum distance from screen edges |
 | `tooltipGap` | `Dp` | `16.dp` | Gap between cutout and tooltip |
 | `tooltipCornerRadius` | `Dp` | `16.dp` | Corner radius for tooltip card |
@@ -299,6 +307,18 @@ enum class ConnectorStyle {
     HORIZONTAL,  // Horizontal line with dot
     VERTICAL,    // Vertical line with dot
     ELBOW,       // L-shaped connector
+    CURVED,      // Smooth quadratic Bezier curve
+}
+```
+
+### ConnectorEndStyle
+
+```kotlin
+enum class ConnectorEndStyle {
+    DOT,     // Small filled circle (default)
+    ARROW,   // Directional arrowhead toward tooltip
+    NONE,    // No endpoint decoration
+    CUSTOM,  // Custom rendering via CoachmarkConfig.customConnectorEnd
 }
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -192,12 +192,72 @@ The connector line links the cutout to the tooltip:
 | `HORIZONTAL` | Straight horizontal line |
 | `ELBOW` | L-shaped with 90° bend |
 | `DIRECT` | Diagonal line pointing directly to tooltip |
+| `CURVED` | Smooth quadratic Bezier curve |
 
 ```kotlin
 CoachmarkTarget(
     id = "target",
     connectorStyle = ConnectorStyle.ELBOW,
     connectorLength = 60.dp,  // Custom length (default: auto)
+    // ...
+)
+
+// Smooth curved connector
+CoachmarkTarget(
+    id = "curved-target",
+    connectorStyle = ConnectorStyle.CURVED,
+    // ...
+)
+```
+
+## Connector End Styles
+
+Customize the endpoint decoration where the connector meets the tooltip:
+
+| Style | Description |
+|-------|-------------|
+| `DOT` | Small filled circle (default) |
+| `ARROW` | Directional arrowhead pointing toward the tooltip |
+| `NONE` | No endpoint decoration |
+| `CUSTOM` | Custom rendering via `DrawScope` lambda |
+
+```kotlin
+// Arrow endpoint
+CoachmarkTarget(
+    id = "arrow-target",
+    connectorEndStyle = ConnectorEndStyle.ARROW,
+    // ...
+)
+```
+
+### Configuring Arrow Size
+
+```kotlin
+CoachmarkConfig(
+    connectorArrowSize = 10.dp,   // Length of arrowhead (default: 10.dp)
+    connectorArrowAngle = 30f,    // Half-angle of arrowhead wings in degrees (default: 30f)
+)
+```
+
+### Custom Endpoint Rendering
+
+Provide a `DrawScope` lambda for full control over the endpoint:
+
+```kotlin
+CoachmarkConfig(
+    customConnectorEnd = { center, angle ->
+        // Draw a diamond shape at the connector endpoint
+        drawCircle(
+            color = Color.Red,
+            radius = 6f,
+            center = center,
+        )
+    },
+)
+
+CoachmarkTarget(
+    id = "custom-end",
+    connectorEndStyle = ConnectorEndStyle.CUSTOM,
     // ...
 )
 ```


### PR DESCRIPTION
## Summary

Update documentation to reflect connector endpoint styles, Bezier curves, and platform support shipped in #23 and #22.

## Changes

**API**
- Document `ConnectorStyle.CURVED` (Bezier curve connectors) in guide and API reference
- Document `ConnectorEndStyle` enum (`DOT`, `ARROW`, `NONE`, `CUSTOM`) with usage examples
- Document new `CoachmarkConfig` properties: `connectorArrowSize`, `connectorArrowAngle`, `customConnectorEnd`
- Add `connectorEndStyle` to `CoachmarkTarget` API reference

**Internal**
- Update platform support from "Android and iOS" to include Desktop (JVM) and Web (Wasm)
- Mark completed roadmap items: connector enhancements (v1.1.0), Desktop/Web support (v2.0.0)

## Breaking Changes

**None**

## Platform Support

- [x] Android
- [x] iOS
- [x] Desktop (JVM)
- [x] Web (Wasm)

## Testing

- [x] Documentation-only change, no code modifications
- [x] Unit tests pass
- [ ] Manual testing on device/emulator
- [ ] `./gradlew :lumen:compileKotlinMetadata` (commonMain)
- [ ] `./gradlew :sample:assembleDebug` (sample app)

## Release Notes

### Features
- Updated docs for connector endpoint styles, Bezier curves, and 4-platform support