### PR TITLE
Deploy Wasm sample demo to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,63 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  GRADLE_OPTS: >-
+    -Dorg.gradle.daemon=false
+    -Dkotlin.incremental=false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build Wasm sample
+        run: ./gradlew :sample:wasmJsBrowserDistribution
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          cp -r docs/* _site/
+          cp -r sample/build/dist/wasmJs/productionExecutable/ _site/demo/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,10 @@ controller.show(
 )
 ```
 
+## Live Demo
+
+Try the interactive [Wasm demo](demo/) in your browser — no install required.
+
 ## Get Started
 
 Check out the [Getting Started](getting-started.md) guide to add Lumen to your project.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -25,6 +25,7 @@
   - [CoachmarkColors](api-reference.md#coachmarkcolors)
 
 - **Links**
+  - [Live Demo](demo/)
   - [GitHub](https://github.com/aldefy/Lumen)
   - [Maven Central](https://central.sonatype.com/artifact/io.github.aldefy/lumen)
   - [Sample App](https://github.com/aldefy/Lumen/tree/main/sample)


### PR DESCRIPTION
## Summary
- Adds `deploy-pages.yml` workflow that builds the Compose Wasm sample and deploys it alongside the Docsify docs site
- Live demo available at `aldefy.github.io/Lumen/demo/`
- Docs site continues at `aldefy.github.io/Lumen/`
- Switches Pages source from legacy branch deploy to GitHub Actions
- Adds "Live Demo" link to docs sidebar and homepage

## How it works
1. Workflow triggers on push to `main` (and manual dispatch)
2. Builds `./gradlew :sample:wasmJsBrowserDistribution`
3. Copies `docs/` + Wasm output into a combined `_site/` directory
4. Deploys via `actions/deploy-pages`

## Test plan
- [ ] Verify CI passes (existing `check.yml` workflow)
- [ ] After merge, verify `deploy-pages` workflow runs successfully
- [ ] Verify `aldefy.github.io/Lumen/` still serves the Docsify docs
- [ ] Verify `aldefy.github.io/Lumen/demo/` loads the Wasm sample app